### PR TITLE
Fix unicode encoding by reflecting changes in mysqlclient-python

### DIFF
--- a/Products/ZMySQLDA/db.py
+++ b/Products/ZMySQLDA/db.py
@@ -552,7 +552,11 @@ class DB(TM):
     def unicode_literal(self, sql_str):
         """ Similar to string_literal but encodes it first.
         """
-        return self.db.unicode_literal(sql_str)
+        try:
+            return self.db.unicode_literal(sql_str)
+        except AttributeError:
+            return self.db.encoders[unicode](sql_str)
+
 
     # Zope 2-phase transaction handling methods
 

--- a/Products/ZMySQLDA/tests/dummy.py
+++ b/Products/ZMySQLDA/tests/dummy.py
@@ -13,6 +13,8 @@
 """ Dummy fixtures for testing
 """
 
+import sys
+
 RESULTS = {'show table status': [['table1', 'engine1', None, None, 5, None,
                                   None, None, None, None, None, None, None,
                                   None, 'my_collation']],
@@ -52,6 +54,11 @@ class FakeConnection:
         self.string_literal_called = False
         self.unicode_literal_called = False
 
+        if sys.version_info[0] > 2:
+            self.unicode_literal = self._unicode_literal
+        else:
+            self.encoders = { unicode: self._unicode_literal }
+
         for k, v in kw.items():
             setattr(self, k, v)
 
@@ -75,5 +82,5 @@ class FakeConnection:
     def string_literal(self, txt):
         self.string_literal_called = txt
 
-    def unicode_literal(self, txt):
+    def _unicode_literal(self, txt):
         self.unicode_literal_called = txt


### PR DESCRIPTION
unicode_literal is not directly accessible in [mysqlclient-python since 1.3.11](https://github.com/PyMySQL/mysqlclient-python/pull/155/files#diff-1ae3b1bf2e25b3800993d7b9742c2b97L240). This PR fixes unicode_literal for Python2.7.